### PR TITLE
Add the yac_clipper to the Mississippi server

### DIFF
--- a/environments/Mississippi/files/galaxy/config/mississippi_tool_list.yml
+++ b/environments/Mississippi/files/galaxy/config/mississippi_tool_list.yml
@@ -1629,3 +1629,8 @@ tools:
   tool_panel_section_id: None
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
+- name: yac_clipper
+  owner: artbio
+  tool_panel_section_id: mississippi_tool_suite
+  tool_panel_section_label: Mississippi Tool Suite
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
I would like to add the yac_clipper to the Mississippi server in order to reproduce the analysis performed using the Galaxy-Workflow-23-29nt_clean.ga workflow from the following article: https://zenodo.org/records/7695838