### PR TITLE
Add the fastqtofasta tool to the Mississippi server

### DIFF
--- a/environments/Mississippi/files/galaxy/config/mississippi_tool_list.yml
+++ b/environments/Mississippi/files/galaxy/config/mississippi_tool_list.yml
@@ -1629,3 +1629,8 @@ tools:
   tool_panel_section_id: None
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu
+- name: fastqtofasta
+  owner: devteam
+  tool_panel_section_id: ngs:_qc_and_manipulation
+  tool_panel_section_label: NGS: QC and manipulation
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
I would like to add the fastqtofasta to the Mississippi server in order to convert Fatsq files to fasta to perform sequence logo