### PR TITLE
Update Galaxy commit IDs in environment configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,20 @@
-[![Test Playbook](https://github.com/ARTbio/galaxyXpand/actions/workflows/test_playbook.yaml/badge.svg)](https://github.com/ARTbio/galaxyXpand/actions/workflows/test_playbook.yaml)
-[![Docker Repository on Quay](https://quay.io/repository/artbioplatform/galaxyxpand/status "Docker Repository on Quay")](https://quay.io/repository/artbioplatform/galaxyxpand)
 ## GalaxyXpand 🌌
 
 **GalaxyXpand** is the next-generation Ansible playbook for automated [Galaxy](https://galaxyproject.org/) server deployment. Developed by the [ARTbio platform](https://artbio.fr/), it serves as the modern successor to *GalaxyKickStart*, designed to deploy production-ready Galaxy instances on cloud environments (e.g., Google Cloud Engine) or bare-metal servers.
 
-
 ### 🚀 Features
-
-
 
 * **Automated Deployment:** Deploys a full Galaxy stack from scratch.
 * **Job Management:** Supports configurations for Slurm or Celery.
 * **Tool Management:** Includes utilities to install Galaxy tools automatically.
 * **Extensible:** Uses standard Ansible roles and collections.
 
-
 ### 📋 Requirements
 
 Before running this playbook, ensure your control node and target machines meet the following requirements.
 
 
-#### Operating System Compatibility
+### Operating System Compatibility
 
 The playbook version you use depends on your target Operating System and the Galaxy version you intend to deploy.
 
@@ -54,25 +48,24 @@ The playbook version you use depends on your target Operating System and the Gal
 
 
 
-    ⚠️ For Ubuntu 20.04 users:
+⚠️ For Ubuntu 20.04 users:
+
+You must switch to the dedicated tag or branch to ensure compatibility with Galaxy release 24.1 or older.
+
+```
+# Example using the tag
+git checkout release_24.1_ubuntu20.04-final
+```
 
 
-    You must switch to the dedicated tag or branch to ensure compatibility with Galaxy release 24.1 or older.
-
-
-    # Example using the tag \
-git checkout release_24.1_ubuntu20.04-final \
-
-
-
-#### Quick Setup
+### Quick Setup
 
 On a fresh Ubuntu machine, installing the dependencies is straightforward. You do not need to manage complex pip environments manually; the system package manager provides a sufficiently recent version of Ansible.
 
 Run the following command on your control node (Ubuntu 24.04 recommended):
-
-sudo apt update && sudo apt install ansible -y \
-
+```
+sudo apt update && sudo apt install ansible -y
+```
 
 
 ### 🏁 Quick Start & Usage
@@ -81,45 +74,41 @@ Once Ansible is installed, follow these steps to deploy Galaxy.
 
 
 #### 1. Setup the Repository
+```
+# Clone the repository and install the required Ansible roles.
+git clone [https://github.com/ARTbio/galaxyXpand.git](https://github.com/ARTbio/galaxyXpand.git)
+cd galaxyXpand
 
-Clone the repository and install the required Ansible roles.
-
-git clone [https://github.com/ARTbio/galaxyXpand.git](https://github.com/ARTbio/galaxyXpand.git) \
-cd galaxyXpand \
- \
-# Install external roles dependencies \
-ansible-galaxy install -r requirements.yml -p roles/ \
-
-
+# Install external roles dependencies
+ansible-galaxy install -r requirements.yml -p roles/
+```
 
 #### 2. Deploy Galaxy
 
 Run the main playbook specifying your target environment inventory (e.g., dev_gce).
+```
+ansible-playbook -i environments/dev_gce/hosts playbook.yml
+```
 
-ansible-playbook -i environments/dev_gce/hosts playbook.yml \
-
-
-
-    **📝 Note:** If executed on a standard GCE VM (e.g., 4 CPUs), this will deploy a full Galaxy instance. Jobs will be managed by either **Celery** or **Slurm**, depending on the configuration defined in your job_conf.xml.
-
+**📝 Note:** If executed on a standard GCE VM (e.g., 4 CPUs), this will deploy a full Galaxy instance. Jobs will be managed by either **Celery** or **Slurm**, depending on the configuration defined in your job_conf.xml.
 
 #### 3. Install Tools
 
 Once Galaxy is running, you can automate the installation of tools (as defined in tool_list.yaml).
-
-ansible-playbook -i environments/dev_gce/hosts install_tools.yml \
-
+```
+ansible-playbook -i environments/dev_gce/hosts install_tools.yml
+```
 
 *This installs the tools described in [tool_list.yaml.sample](https://github.com/ARTbio/ansible-galaxy-tools/blob/galaxyXpand/files/tool_list.yaml.sample).*
 
+### 🔧 Utilities & Debugging
 
-#### 🔧 Utilities & Debugging
-
-Inspect Variables
+#### Inspect Variables
 
 To debug or verify the configuration of a specific environment (e.g., Mississippi) without applying changes, use the showvars.yml playbook.
-
-ansible-playbook -i environments/Mississippi/hosts showvars.yml \
+```
+ansible-playbook -i environments/Mississippi/hosts showvars.yml
+```
 
 
 *This will display the computed value of all ansible variables for the target environment.*

--- a/README.md
+++ b/README.md
@@ -1,46 +1,294 @@
 [![Test Playbook](https://github.com/ARTbio/galaxyXpand/actions/workflows/test_playbook.yaml/badge.svg)](https://github.com/ARTbio/galaxyXpand/actions/workflows/test_playbook.yaml)
 [![Docker Repository on Quay](https://quay.io/repository/artbioplatform/galaxyxpand/status "Docker Repository on Quay")](https://quay.io/repository/artbioplatform/galaxyxpand)
+## GalaxyXpand 🌌
 
-# galaxyXpand
+**GalaxyXpand** is the next-generation Ansible playbook for automated [Galaxy](https://galaxyproject.org/) server deployment. Developed by the [ARTbio platform](https://artbio.fr/), it serves as the modern successor to *GalaxyKickStart*, designed to deploy production-ready Galaxy instances on cloud environments (e.g., Google Cloud Engine) or bare-metal servers.
 
-Our Next Generation of Ansible Playbook for Galaxy server deployment, **version >= 'release_22.05'**
 
-Documentation is coming soon.
-
-Requirements
-```
-
-Python >= 3.8 
-ansible >= 3.0
-```
-
-### Example of use
-
-```
-apt update
-apt install python3-pip python3-virtualenv
-pip install ansible==3.0
-git clone https://github.com/ARTbio/galaxyXpand.git
-cd galaxyXpand
-ansible-galaxy install -r requirements.yml -p roles/
-ansible-playbook -i environments/dev_gce/hosts playbook.yml
-```
-If executed on a GCE VM (4 cpu), this will deploy Galaxy with job being managed either
-with celery or slurm (as defined in job_conf.xml)
-
-Then,
-```
-ansible-playbook -i environments/dev_gce/hosts install_tools.yml
-```
-installs 2 tools described as described in [tool_list.yaml.sample](https://github.com/ARTbio/ansible-galaxy-tools/blob/galaxyXpand/files/tool_list.yaml.sample)
-
-----
-```
-ansible-playbook -i environments/Mississippi/hosts showvars.yml
-```
-This will display the value of all ansible variables for the environment Mississippi
+### 🚀 Features
 
 
 
-Our previous [GalaxyKickStart](https://github.com/artbio/galaxykickstart) Ansible playbook
-supports the deployment of Galaxy releases <= 22.01. It is not supported anymore.
+* **Automated Deployment:** Deploys a full Galaxy stack from scratch.
+* **Job Management:** Supports configurations for Slurm or Celery.
+* **Tool Management:** Includes utilities to install Galaxy tools automatically.
+* **Extensible:** Uses standard Ansible roles and collections.
+
+
+### 📋 Requirements
+
+Before running this playbook, ensure your control node and target machines meet the following requirements.
+
+
+#### Operating System Compatibility
+
+The playbook version you use depends on your target Operating System and the Galaxy version you intend to deploy.
+
+
+<table>
+  <tr>
+   <td><strong>Target OS</strong>
+   </td>
+   <td><strong>Galaxy Version</strong>
+   </td>
+   <td><strong>Playbook Branch / Tag</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Ubuntu 24.04 LTS</strong>
+   </td>
+   <td>Latest (Current)
+   </td>
+   <td>main
+   </td>
+  </tr>
+  <tr>
+   <td><strong>Ubuntu 20.04 LTS</strong>
+   </td>
+   <td>$\le$ 24.1
+   </td>
+   <td>final/release_24.1_ubuntu20.04-final
+   </td>
+  </tr>
+</table>
+
+
+
+    ⚠️ For Ubuntu 20.04 users:
+
+
+    You must switch to the dedicated tag or branch to ensure compatibility with Galaxy release 24.1 or older.
+
+
+    # Example using the tag \
+git checkout release_24.1_ubuntu20.04-final \
+
+
+
+#### Quick Setup
+
+On a fresh Ubuntu machine, installing the dependencies is straightforward. You do not need to manage complex pip environments manually; the system package manager provides a sufficiently recent version of Ansible.
+
+Run the following command on your control node (Ubuntu 24.04 recommended):
+
+sudo apt update && sudo apt install ansible -y \
+
+
+
+### 🏁 Quick Start & Usage
+
+Once Ansible is installed, follow these steps to deploy Galaxy.
+
+
+#### 1. Setup the Repository
+
+Clone the repository and install the required Ansible roles.
+
+git clone [https://github.com/ARTbio/galaxyXpand.git](https://github.com/ARTbio/galaxyXpand.git) \
+cd galaxyXpand \
+ \
+# Install external roles dependencies \
+ansible-galaxy install -r requirements.yml -p roles/ \
+
+
+
+#### 2. Deploy Galaxy
+
+Run the main playbook specifying your target environment inventory (e.g., dev_gce).
+
+ansible-playbook -i environments/dev_gce/hosts playbook.yml \
+
+
+
+    **📝 Note:** If executed on a standard GCE VM (e.g., 4 CPUs), this will deploy a full Galaxy instance. Jobs will be managed by either **Celery** or **Slurm**, depending on the configuration defined in your job_conf.xml.
+
+
+#### 3. Install Tools
+
+Once Galaxy is running, you can automate the installation of tools (as defined in tool_list.yaml).
+
+ansible-playbook -i environments/dev_gce/hosts install_tools.yml \
+
+
+*This installs the tools described in [tool_list.yaml.sample](https://github.com/ARTbio/ansible-galaxy-tools/blob/galaxyXpand/files/tool_list.yaml.sample).*
+
+
+#### 🔧 Utilities & Debugging
+
+Inspect Variables
+
+To debug or verify the configuration of a specific environment (e.g., Mississippi) without applying changes, use the showvars.yml playbook.
+
+ansible-playbook -i environments/Mississippi/hosts showvars.yml \
+
+
+*This will display the computed value of all ansible variables for the target environment.*
+
+
+### ⚙️ Configuration & Actionable Variables
+
+This playbook relies on a **hierarchical configuration architecture**.
+
+
+
+1. **Defaults**: Global defaults are defined in environments/000_cross_env_vars.
+2. **Overrides**: Specific settings are defined in environments/&lt;your_env>/group_vars/all.
+
+    **ℹ️ Note:** The main galaxy_config dictionary uses a **recursive deep merge**. You only need to define the specific keys you want to change or add in your environment; everything else is inherited from the global defaults.
+
+
+
+#### 1. Core Deployment Variables
+
+Control the software versions and main feature flags.
+
+
+<table>
+  <tr>
+   <td><strong>Variable</strong>
+   </td>
+   <td><strong>Default / Example</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>galaxy_commit_id
+   </td>
+   <td>release_25.1
+   </td>
+   <td>The Galaxy Git branch or tag to deploy (e.g., downgrade to release_24.1 for stability).
+   </td>
+  </tr>
+  <tr>
+   <td>miniconda_installer_version
+   </td>
+   <td>25.11.0-1
+   </td>
+   <td>Pinned version of the Miniforge installer to ensure reproducibility.
+   </td>
+  </tr>
+  <tr>
+   <td>install_slurm
+   </td>
+   <td>true
+   </td>
+   <td>Feature flag to install and configure the Slurm workload manager.
+   </td>
+  </tr>
+  <tr>
+   <td>install_uptime
+   </td>
+   <td>false
+   </td>
+   <td>Feature flag to install Uptime Kuma for monitoring.
+   </td>
+  </tr>
+</table>
+
+
+
+#### 2. Galaxy Configuration (galaxy_config)
+
+Key functional settings nested under galaxy_config. Due to the deep merge strategy, you can override specific leaves of the tree.
+
+
+<table>
+  <tr>
+   <td><strong>YAML Path</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><strong>galaxy</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>.admin_users
+   </td>
+   <td>Comma-separated list of admin emails. <strong>Replaces</strong> the default list entirely.
+   </td>
+  </tr>
+  <tr>
+   <td>.brand
+   </td>
+   <td>Custom text or HTML label for the navigation bar (e.g., "🧬 Ag2025").
+   </td>
+  </tr>
+  <tr>
+   <td>.enable_quotas
+   </td>
+   <td>true or false. Enforce storage limits for users.
+   </td>
+  </tr>
+  <tr>
+   <td><strong>gravity</strong>
+   </td>
+   <td>
+   </td>
+  </tr>
+  <tr>
+   <td>.gunicorn.bind
+   </td>
+   <td>Network binding. Use unix:... for local sockets or 0.0.0.0:4000 for exposing Galaxy (Docker/Cloud).
+   </td>
+  </tr>
+  <tr>
+   <td>.gunicorn.workers
+   </td>
+   <td>Number of Gunicorn workers handling web requests.
+   </td>
+  </tr>
+  <tr>
+   <td>.celery.workers
+   </td>
+   <td>Number of Celery workers for background tasks (if added to the environment).
+   </td>
+  </tr>
+</table>
+
+
+
+#### 3. Tool Management
+
+Tools are not defined in the variables directly but referenced via external YAML files.
+
+galaxy_tools_tool_list_files: \
+  - "environments/&lt;your_env>/files/your_tool_list.yaml" \
+
+
+
+#### 4. Infrastructure & Performance
+
+
+##### Slurm (Compute)
+
+Slurm resources are often calculated dynamically via Jinja2 filters in the playbook, but can be overridden.
+
+
+
+* **slurm_nodes**: Defines CPU/RAM per node.
+    * *Default behavior:* Auto-calculates RealMemory as 95% of total RAM.
+* **slurm_partitions**: Defines queues (e.g., debug).
+    * *Crucial:* Partition names must match the destinations defined in your files/job_conf.yml.
+
+
+##### NGINX (Proxy)
+
+
+
+* **nginx_conf_http.client_max_body_size**: Max upload size (e.g., 10g). Essential for large datasets (FASTQ/BAM).
+* **nginx_conf_http.gzip_comp_level**: Compression level (default 6).
+
+
+#### ⚠️ Important Configuration Gotchas
+
+
+
+1. Job Handlers Naming: \
+If you rename handler pools in galaxy_config (e.g., changing job-handler to job-handlers), ensure your job_conf.yml uses the assign: - db-skip-locked mechanism. This allows any available handler to pick up jobs regardless of the specific process name.
+2. Job Destinations: \
+Always verify that every destination ID used in files/job_conf.yml refers to a valid cluster/partition defined in slurm_partitions (in group_vars). A mismatch will cause jobs to fail immediately.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,7 +2,8 @@
 interpreter_python = /usr/bin/python3
 inventory = ./environments/dev_gce/hosts
 # Use the YAML callback plugin.
-stdout_callback = yaml
+stdout_callback = ansible.builtin.default
+callback_result_format = yaml
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks = True
 # vault_password_file = ../ansible_vault_password

--- a/environments/000_cross_env_vars
+++ b/environments/000_cross_env_vars
@@ -14,7 +14,7 @@ install_slurm: true
 nginx_conf_user: "www-data galaxy"
 
 # Galaxy common to all hosts
-galaxy_commit_id: release_24.1
+galaxy_commit_id: release_25.1
 galaxy_user_name: galaxy
 galaxy_db_name: galaxy
 galaxy_config_perms: 0664

--- a/environments/000_cross_env_vars
+++ b/environments/000_cross_env_vars
@@ -33,8 +33,15 @@ galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
 galaxy_force_checkout: true
 galaxy_venv_dir: "/home/galaxy/galaxy/.venv"
 miniconda_prefix: "{{ galaxy_tool_dependency_dir }}/_conda"
-miniconda_installer_python: "3.12"
+# Use Miniforge (Galaxy standard, licence issue with Miniconda)
+miniconda_distribution: "miniforge"
+# Exact version for direct download (to avoid latest changing unexpectedly)
+miniconda_installer_version: "25.11.0-1"
+# Update Conda/Mamba if recent version ex
+# leave 'latest' here, it's different from installing it.
 miniconda_version: "latest"
+# IMPORTANT : block modification of the installed Python unless absolutely necessary
+miniconda_base_env_packages: []
 miniconda_channels:
   - conda-forge
   - bioconda

--- a/environments/000_cross_env_vars
+++ b/environments/000_cross_env_vars
@@ -33,7 +33,7 @@ galaxy_config_file: "{{ galaxy_config_dir }}/galaxy.yml"
 galaxy_force_checkout: true
 galaxy_venv_dir: "/home/galaxy/galaxy/.venv"
 miniconda_prefix: "{{ galaxy_tool_dependency_dir }}/_conda"
-miniconda_installer_python: "3.8"
+miniconda_installer_python: "3.12"
 miniconda_version: "latest"
 miniconda_channels:
   - conda-forge

--- a/environments/ARTbio/group_vars/all/galaxy
+++ b/environments/ARTbio/group_vars/all/galaxy
@@ -2,6 +2,7 @@
 # Galaxy
 galaxy_manage_cleanup: yes  # Install a cron job to clean up Galaxy framework and job execution temporary
 galaxy_tool_dependency_dir: "{{ galaxy_root }}/tool_dependencies"
+galaxy_commit_id: release_24.1 # freeze to 24.1 release until artbio server running Ubuntu 24.04 is stable.
 
 galaxy_config:
   gravity:

--- a/environments/Conect/group_vars/all/galaxy
+++ b/environments/Conect/group_vars/all/galaxy
@@ -78,9 +78,9 @@ galaxy_config:
 
 # Welcome html page variables
 _conect_info: |
-  <strong>Ubuntu system was upgraded to
+  <strong>Galaxy is now running
   <br>
-  version 24.04 LTS Noble (2025-10-31)</strong>
+  release_25.1 (Dec 2025)</strong>
 conect_info: "{{ _conect_info | indent(width=10, first=True) }}"
 
 # deploy galaxy configuration files

--- a/environments/Mississippi/group_vars/all/galaxy
+++ b/environments/Mississippi/group_vars/all/galaxy
@@ -74,9 +74,9 @@ galaxy_config:
 
 # Welcome html page variables
 _Mississippi_info: |
-  <strong>Ubuntu system was upgraded to
+  <strong>Galaxy is now running
   <br>
-  version 24.04 LTS Noble (Nov 2025)</strong>
+  release_25.1 (Dec 2025)</strong>
 Mississippi_info: "{{ _Mississippi_info | indent(width=12, first=True) }}"
 
 # deploy galaxy configuration files

--- a/environments/ag2025/files/job_conf.yml
+++ b/environments/ag2025/files/job_conf.yml
@@ -89,7 +89,7 @@ tools:
     destination: "cluster_3"
 
   - id: "samtools_rmdup"
-    destination: "cluster_4"
+    destination: "cluster_3"
 
   - id: "sambamba"
     destination: "cluster_3"

--- a/environments/dev_gce/group_vars/all/galaxy
+++ b/environments/dev_gce/group_vars/all/galaxy
@@ -2,7 +2,7 @@
 # optimize 2 cpu VM GCE
 
 # development branch
-galaxy_commit_id: release_24.1
+galaxy_commit_id: release_25.1
 
 galaxy_config:
   gravity:

--- a/playbook.yml
+++ b/playbook.yml
@@ -53,6 +53,19 @@
         mode: '0755'
         state: directory
 
+    - name: "FIX: Clean out existing Node.js binaries from the venv to avoid nodeenv errors during Galaxy upgrade"
+      file:
+        path: "/home/galaxy/galaxy/.venv/{{ item }}"
+        state: absent
+      loop:
+        - "lib/node_modules"
+        - "bin/node"
+        - "bin/npm"
+        - "bin/npx"
+        - "bin/corepack"
+      tags:
+        - galaxy_upgrade_fix
+
     - name: Merge common and specific Galaxy configurations
       ansible.builtin.set_fact:
         galaxy_config: "{{ common_galaxy_config | ansible.builtin.combine(galaxy_config, recursive=true) }}"

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,8 +1,6 @@
 ---
-# playbook.yml — installation Galaxy + Slurm + DRMAA (Ubuntu ≥22.04)
-# Version simplifiée — utilise le PPA Natefoo officiel pour slurm-drmaa
-# Auteur : Christophe Antoniewski / ARTbio
-# Date   : 2025-10-25
+# Instal Galaxy + Slurm + DRMAA (Ubuntu ≥22.04)
+# Use Natefoo PPA for slurm-drmaa
 
 - name: Install PostgreSQL objects
   hosts: dbservers

--- a/playbook.yml
+++ b/playbook.yml
@@ -63,6 +63,7 @@
         - "bin/npm"
         - "bin/npx"
         - "bin/corepack"
+      become: true
       tags:
         - galaxy_upgrade_fix
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -54,7 +54,7 @@
         state: directory
 
     - name: "FIX: Clean out existing Node.js binaries from the venv to avoid nodeenv errors during Galaxy upgrade"
-      file:
+      ansible.builtin.file:
         path: "/home/galaxy/galaxy/.venv/{{ item }}"
         state: absent
       loop:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 - src: galaxyproject.galaxy
-  version: 0.12.0     # meilleure compatibilité Gravity et handlers
+  version: 0.12.1     # meilleure compatibilité Gravity et handlers
 - src: galaxyproject.nginx
   version: 1.0.0
 - src: galaxyproject.postgresql

--- a/scripts/node_upgrade_issue.sh
+++ b/scripts/node_upgrade_issue.sh
@@ -1,0 +1,65 @@
+# 1. Supprimer le dossier contenant les modules globaux de Node dans le venv
+rm -rf /home/galaxy/galaxy/.venv/lib/node_modules
+
+# 2. Supprimer tous les exécutables liés à Node dans le dossier bin
+rm -f /home/galaxy/galaxy/.venv/bin/node
+rm -f /home/galaxy/galaxy/.venv/bin/npm
+rm -f /home/galaxy/galaxy/.venv/bin/npx
+rm -f /home/galaxy/galaxy/.venv/bin/corepack
+
+# in case of error due to pre-existing node during 24.1 to 25.1 upgrade:
+# TASK [galaxyproject.galaxy : Install or upgrade node] *********************************************************************************************************************************************************************************************************************
+# fatal: [localhost]: FAILED! =>
+#     changed: true
+#     cmd:
+#     - nodeenv
+#     - -n
+#     - 22.13.0
+#     - -p
+#     delta: '0:00:03.114150'
+#     end: '2025-12-19 13:17:27.075784'
+#     msg: non-zero return code
+#     rc: 1
+#     start: '2025-12-19 13:17:23.961634'
+#     stderr: |-
+#         /home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py:48: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
+#           from pkg_resources import parse_version
+#          * Install prebuilt node (22.13.0) ....
+#         Traceback (most recent call last):
+#           File "/home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py", line 652, in copytree
+#             shutil.copytree(s, d, symlinks, ignore)
+#           File "/usr/lib/python3.12/shutil.py", line 600, in copytree
+#             return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
+#                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#           File "/usr/lib/python3.12/shutil.py", line 498, in _copytree
+#             os.makedirs(dst, exist_ok=dirs_exist_ok)
+#           File "<frozen os>", line 225, in makedirs
+#         FileExistsError: [Errno 17] File exists: '/home/galaxy/galaxy/.venv/bin'
+
+#         During handling of the above exception, another exception occurred:
+
+#         Traceback (most recent call last):
+#           File "/home/galaxy/galaxy/.venv/bin/nodeenv", line 7, in <module>
+#             sys.exit(main())
+#                      ^^^^^^
+#           File "/home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py", line 1122, in main
+#             create_environment(env_dir, args)
+#           File "/home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py", line 998, in create_environment
+#             install_node(env_dir, src_dir, args)
+#           File "/home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py", line 755, in install_node
+#             install_node_wrapped(env_dir, src_dir, args)
+#           File "/home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py", line 790, in install_node_wrapped
+#             copy_node_from_prebuilt(env_dir, src_dir, args.node)
+#           File "/home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py", line 682, in copy_node_from_prebuilt
+#             copytree(src_folder, dest, True)
+#           File "/home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py", line 654, in copytree
+#             copytree(s, d, symlinks, ignore)
+#           File "/home/galaxy/galaxy/.venv/lib/python3.12/site-packages/nodeenv.py", line 659, in copytree
+#             os.symlink(os.readlink(s), d)
+#         FileExistsError: [Errno 17] File exists: '../lib/node_modules/npm/bin/npx-cli.js' -> '/home/galaxy/galaxy/.venv/bin/npx'
+#     stderr_lines: <omitted>
+#     stdout: ''
+#     stdout_lines: <omitted>
+
+# PLAY RECAP ****************************************************************************************************************************************************************************************************************************************************************
+# localhost                  : ok=88   changed=12   unreachable=0    failed=1    skipped=51   rescued=0    ignored=0


### PR DESCRIPTION
Bump the global Galaxy commit ID to release_25.1 in 000_cross_env_vars. Add and freeze galaxy_commit_id to release_24.1 in ARTbio group_vars until stability on Ubuntu 24.04.